### PR TITLE
Adds support for laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "laravel 7",
         "laravel 8",
         "laravel 9",
-        "laravel 10"
+        "laravel 10",
+        "laravel 11"
     ],
     "autoload": {
         "psr-4": {
@@ -32,9 +33,9 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0|^8.1",
-        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
-        "guzzlehttp/guzzle": "^6.0|^7.0|^8.0|^9.0"
+        "php": "^7.1|^8.0|^8.1|^8.2",
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "guzzlehttp/guzzle": "^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0",


### PR DESCRIPTION
Updated the following packages to support Laravel 11:

- PHP: ^8.2
- illuminate/support: ^10.0
- guzzlehttp/guzzle: ^9.0